### PR TITLE
Responsive search result buttons

### DIFF
--- a/src/components/ResultsBody/ResultsBody.css
+++ b/src/components/ResultsBody/ResultsBody.css
@@ -14,3 +14,9 @@ h2{
 }
 
 
+@media (max-width: 720px) {
+    .results-container{
+        width: 100%;
+        margin: 0%;
+    }
+}

--- a/src/components/SearchOptions/SearchOptions.css
+++ b/src/components/SearchOptions/SearchOptions.css
@@ -1,6 +1,6 @@
 .result-selection {
     display: flex;
-    width: 80%;
+    width: 95%;
     margin: auto;
     justify-content: space-between;
 }

--- a/src/components/SearchOptions/SearchOptions.css
+++ b/src/components/SearchOptions/SearchOptions.css
@@ -1,0 +1,37 @@
+.result-selection {
+    display: flex;
+    width: 80%;
+    margin: auto;
+    justify-content: space-between;
+}
+
+.results-button {
+    width: 110px;
+    border-radius: 15px;
+}
+.results-button> .text {
+    margin-top: 1px;
+    margin-bottom: 1px;
+}
+.result-nobackground-button {
+    width: 110px;
+    background-color: white;
+}
+
+.result-nobackground-button>.text {
+    font-weight: none;
+    color: black;
+    margin-top: 1px;
+    margin-bottom: 1px;
+}
+
+.result-nobackground-button:hover {
+    background-color: white;
+}
+
+
+@media (min-width: 720px) {
+    .result-selection {
+        display: none;
+    }
+}

--- a/src/components/SearchOptions/SearchOptions.js
+++ b/src/components/SearchOptions/SearchOptions.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import './SearchOptions.css'
 import SolidButton from '../../components/SolidButton/SolidButton';
-import { useState } from 'react';
 const SearchOptions = (props) => {
-    const [ResultButton, sethResultButton] = useState(true);
-    const [FilterButtton, setFilterButton] = useState(true);
     if (props.SearchState === true) {
         return (
 
@@ -15,7 +12,7 @@ const SearchOptions = (props) => {
                     onClick={props.onClick}
                 />
                 <SolidButton
-                    className="results-button filters"
+                    className="results-button"
                     text="Filters"
                     onClick={props.onClick}
                 />
@@ -32,7 +29,7 @@ const SearchOptions = (props) => {
                     onClick={props.onClick}
                 />
                 <SolidButton
-                    className="result-nobackground-button filters"
+                    className="result-nobackground-button"
                     text="Filters"
                     onClick={props.onClick}
                 />

--- a/src/components/SearchOptions/SearchOptions.js
+++ b/src/components/SearchOptions/SearchOptions.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import './SearchOptions.css'
+import SolidButton from '../../components/SolidButton/SolidButton';
+import { useState } from 'react';
+const SearchOptions = (props) => {
+    const [ResultButton, sethResultButton] = useState(true);
+    const [FilterButtton, setFilterButton] = useState(true);
+    if (props.SearchState === true) {
+        return (
+
+            <div className="result-selection" >
+                <SolidButton
+                    className="result-nobackground-button"
+                    text="Results"
+                    onClick={props.onClick}
+                />
+                <SolidButton
+                    className="results-button filters"
+                    text="Filters"
+                    onClick={props.onClick}
+                />
+
+            </div>
+        );
+    }
+    else {
+        return (
+            <div className="result-selection" >
+                <SolidButton
+                    className="results-button"
+                    text="Results"
+                    onClick={props.onClick}
+                />
+                <SolidButton
+                    className="result-nobackground-button filters"
+                    text="Filters"
+                    onClick={props.onClick}
+                />
+            </div>
+
+        )
+    }
+}
+
+export default SearchOptions;

--- a/src/components/SolidButton/SolidButton.js
+++ b/src/components/SolidButton/SolidButton.js
@@ -10,4 +10,4 @@ const SolidButton = props => {
     );
 }
 
-export default SolidButton;
+export default SolidButton; 

--- a/src/components/TeamCard/TeamCard.css
+++ b/src/components/TeamCard/TeamCard.css
@@ -8,6 +8,7 @@
     border-radius: 15px;
     padding: 15px;
     text-align: start;
+   
 }
 
 .card img {

--- a/src/pages/Results/Results.css
+++ b/src/pages/Results/Results.css
@@ -11,7 +11,7 @@
     padding: 30px;
 }
 
-.filters-container > * {
+.filters-container>* {
     margin-bottom: 30px;
 }
 
@@ -28,4 +28,24 @@ h2 {
 .Experience-Level {
     display: flex;
     flex-direction: row;
+}
+
+.display-phone {
+    display: none;
+}
+
+@media (max-width: 720px) {
+
+    .filters-container {
+        width: 100%;
+        margin: auto;
+    }
+
+    .display-desktop {
+        display: none;
+    }
+
+    .display-phone {
+        display: block;
+    }
 }

--- a/src/pages/Results/Results.js
+++ b/src/pages/Results/Results.js
@@ -8,6 +8,7 @@ import checkboxes from '../../data/checkboxes';
 import Checkbox from '../../components/Checkbox/Checkbox';
 import SolidButton from '../../components/SolidButton/SolidButton';
 import PageHeader from '../../components/PageHeader/PageHeader';
+import SearchOptions from '../../components/SearchOptions/SearchOptions';
 import SearchingArt from '../../img/searching_art.svg';
 import DifficultyExplanation from '../../components/DifficultyExplanation/DifficultyExplanation';
 
@@ -16,6 +17,7 @@ const Results = () => {
     const param = useParams();
     const [text, setText] = useState(decodeURIComponent(param.userText));
     const [checkedItems, setCheckedItems] = useState({});
+    const [SearchSelected, setSearchResult] = useState(true);
 
     const search = input => {
         console.log(`searched for ${input}`)
@@ -23,32 +25,40 @@ const Results = () => {
     }
 
     const handleChange = (event, category, predicate) => {
-        setCheckedItems({ ...checkedItems, [event.target.name]: {
-            checked: event.target.checked,
-            category: category,
-            predicate: predicate,
-        }});
+        setCheckedItems({
+            ...checkedItems, [event.target.name]: {
+                checked: event.target.checked,
+                category: category,
+                predicate: predicate,
+            }
+        });
     }
 
     return (
         <div>
-            <PageHeader 
-                header="Search Results" 
-                subheader={<SearchandSuggested searchFunction={search} text={text}/>}
+
+            <PageHeader
+                header="Search Results"
+                subheader={<SearchandSuggested searchFunction={search} text={text} />}
                 img={SearchingArt}
             />
-            <div className="results-page-section">
+
+            <SearchOptions
+                SearchState={SearchSelected}
+                onClick={() => setSearchResult(!SearchSelected)}
+            />
+
+            <div className="results-page-section display-desktop">
                 <ResultsBody
                     text={text}
                     checkedItems={checkedItems}
                 />
-                
                 <div className="filters-container">
-                    <SolidButton text="Generate Pathway" onClick={() => navigate("/quiz")}/>
+                    <SolidButton text="Generate Pathway" onClick={() => navigate("/quiz")} />
                     {Object.keys(checkboxes).map(key => (
                         <div className="filter-category">
                             <h3> {key} </h3>
-                            { checkboxes[key].names.map(item => ( key !== "Experience Level" ? 
+                            {checkboxes[key].names.map(item => (key !== "Experience Level" ?
                                 <div>
                                     <Checkbox name={item.name} checked={checkedItems[item.name]?.checked} onChange={event => handleChange(event, key, checkboxes[key].predicate)} />
                                     <label key={item.name}>
@@ -60,12 +70,42 @@ const Results = () => {
                                     <Checkbox name={item.name} checked={checkedItems[item.name]?.checked} onChange={event => handleChange(event, key, checkboxes[key].predicate)} />
                                     <DifficultyExplanation difficulty={item.name} />
                                 </div>
-                                ))
+                            ))
                             }
                         </div>
                     ))}
                 </div>
             </div>
+            <div className="results-page-section display-phone">
+                {SearchSelected ? <ResultsBody
+                    text={text}
+                    checkedItems={checkedItems}
+                /> :
+                    <div className="filters-container">
+                        <SolidButton text="Generate Pathway" onClick={() => navigate("/quiz")} />
+                        {Object.keys(checkboxes).map(key => (
+                            <div className="filter-category">
+                                <h3> {key} </h3>
+                                {checkboxes[key].names.map(item => (key !== "Experience Level" ?
+                                    <div>
+                                        <Checkbox name={item.name} checked={checkedItems[item.name]?.checked} onChange={event => handleChange(event, key, checkboxes[key].predicate)} />
+                                        <label key={item.name}>
+                                            {item.name}
+                                        </label>
+                                    </div>
+                                    :
+                                    <div className='Experience-Level'>
+                                        <Checkbox name={item.name} checked={checkedItems[item.name]?.checked} onChange={event => handleChange(event, key, checkboxes[key].predicate)} />
+                                        <DifficultyExplanation difficulty={item.name} />
+                                    </div>
+                                ))
+                                }
+                            </div>
+                        ))}
+                    </div>
+                }
+            </div>
+
         </div>
     )
 }


### PR DESCRIPTION
I added a filter and result button when the website is viewed on phone based on the Figma design. It will display filter options or the result depending on which button is selected(has a toggle behavior).
I think there should be a simpler way of displaying ResultsBody and filters-container instead of having a phone and desktop version, but I couldn't think of a way to do it.  
